### PR TITLE
docs: Clarified location of rootfs.ext4

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -210,7 +210,8 @@ To boot PetaLinux on hardware via SD card:
 #. Create the root file system using dd:
 
    .. code-block:: console
-   
+      
+      $ cd /<petalinux-project>/images/linux/
       $ sudo dd if=rootfs.ext4 of=/dev/sdX2
       $ sync
    


### PR DESCRIPTION
Added missing directory change for location of rootfs.ext4 within image directory. Small note for clarification on location.